### PR TITLE
Add Actuator Health/Info Endpoints and Git Metadata API with Lombok Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.tacticalhacker</groupId>
 	<artifactId>th-scribes-backend</artifactId>
-	<version>2025.4.0-SNAPSHOT</version>
+	<version>2025.4.1-SNAPSHOT</version>
 	<name>th-scribes-backend</name>
 	<description>BackEnd Repository for TH-Scribes Official Website</description>
 	<url/>
@@ -46,6 +46,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.38</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -53,6 +63,48 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+				<version>5.0.0</version>
+				<executions>
+					<execution>
+						<id>get-the-git-infos</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+						<phase>initialize</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<dateFormat>yyyy-MM-dd HH:mm:ss</dateFormat>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<generateGitPropertiesFilename>${basedir}/src/main/resources/git.properties</generateGitPropertiesFilename>
+					<includeOnlyProperties>
+						<includeOnlyProperty>^git.tags$</includeOnlyProperty>
+						<includeOnlyProperty>^git.branch$</includeOnlyProperty>
+						<includeOnlyProperty>^git.dirty$</includeOnlyProperty>
+						<includeOnlyProperty>^git.remote.origin.url$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.full$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.id.describe-short$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.user.name$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.user.email$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.message.full$</includeOnlyProperty>
+						<includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+						<includeOnlyProperty>^git.closest.tag.name$</includeOnlyProperty>
+						<includeOnlyProperty>^git.closest.tag.commit.count$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.user.name$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.user.email$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.time$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.host$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.version$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.number$</includeOnlyProperty>
+						<includeOnlyProperty>^git.build.number.unique$</includeOnlyProperty>
+					</includeOnlyProperties>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/tacticalhacker/th_scribes_backend/config/GitConfig.java
+++ b/src/main/java/com/tacticalhacker/th_scribes_backend/config/GitConfig.java
@@ -1,0 +1,12 @@
+package com.tacticalhacker.th_scribes_backend.config;
+
+import com.tacticalhacker.th_scribes_backend.model.GitData;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource(value = "classpath:git.properties", ignoreResourceNotFound = true)
+@EnableConfigurationProperties(GitData.class)
+public class GitConfig {
+}

--- a/src/main/java/com/tacticalhacker/th_scribes_backend/controller/GitController.java
+++ b/src/main/java/com/tacticalhacker/th_scribes_backend/controller/GitController.java
@@ -1,0 +1,22 @@
+package com.tacticalhacker.th_scribes_backend.controller;
+
+import com.tacticalhacker.th_scribes_backend.model.GitData;
+import com.tacticalhacker.th_scribes_backend.service.GitService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/git")
+public class GitController {
+
+    @Autowired
+    GitService gitService;
+
+    @GetMapping("/info")
+    public GitData getGitInfo() {
+        return gitService.getGitInfo();
+    }
+
+}

--- a/src/main/java/com/tacticalhacker/th_scribes_backend/model/GitData.java
+++ b/src/main/java/com/tacticalhacker/th_scribes_backend/model/GitData.java
@@ -1,0 +1,82 @@
+package com.tacticalhacker.th_scribes_backend.model;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "git")
+public class GitData {
+    private String branch;
+    private Build build;
+    private Closest closest;
+    private Commit commit;
+    private Boolean dirty;
+    private Remote remote;
+    private String tags;
+
+    @Data
+    public static class Build {
+        private String host;
+        private String time;
+        private User user;
+        private String version;
+
+        @Data
+        public static class User {
+            private String email;
+            private String name;
+        }
+    }
+
+    @Data
+    public static class Closest {
+        private Tag tag;
+
+        @Data
+        public static class Tag {
+            private Commit commit;
+            private String name;
+
+            @Data
+            public static class Commit {
+                private Integer count;
+            }
+        }
+    }
+
+    @Data
+    public static class Commit {
+        private Id id;
+        private Message message;
+        private String time;
+        private User user;
+
+        @Data
+        public static class Id {
+            private String abbrev;
+            private String describe;
+            private String describeShort;
+        }
+
+        @Data
+        public static class Message {
+            private String full;
+        }
+
+        @Data
+        public static class User {
+            private String email;
+            private String name;
+        }
+    }
+
+    @Data
+    public static class Remote {
+        private Origin origin;
+
+        @Data
+        public static class Origin {
+            private String url;
+        }
+    }
+}

--- a/src/main/java/com/tacticalhacker/th_scribes_backend/service/GitService.java
+++ b/src/main/java/com/tacticalhacker/th_scribes_backend/service/GitService.java
@@ -1,0 +1,16 @@
+package com.tacticalhacker.th_scribes_backend.service;
+
+import com.tacticalhacker.th_scribes_backend.model.GitData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GitService {
+
+    private final GitData gitData;
+
+    public GitData getGitInfo() {
+        return gitData;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=th-scribes-backend
+
+management.endpoints.web.exposure.include=health,info


### PR DESCRIPTION
## 🚀 What's New

This PR introduces enhancements focused on observability and code maintainability:

### ✅ Spring Boot Actuator Integration
- Enabled standard actuator endpoints:
  - `/actuator/health`
  - `/actuator/info`

### 🧬 Git Metadata API
- Introduced a new REST endpoint to expose Git metadata.
- Data is sourced from the auto-generated `git.properties` file (via `git-commit-id-maven-plugin`).
- Implemented a `GitData` class using `@ConfigurationProperties` for clean and structured mapping.

### 🍃 Lombok Refactor
- Reduced boilerplate with Lombok annotations:
  - Applied `@Data` to configuration and model classes.

---

These changes lay the groundwork for better DevOps integration, runtime visibility, and simplified model management.
